### PR TITLE
Simplified validation

### DIFF
--- a/LoopFollow/Remote/LoopAPNS/LoopAPNSRemoteView.swift
+++ b/LoopFollow/Remote/LoopAPNS/LoopAPNSRemoteView.swift
@@ -6,7 +6,6 @@ import SwiftUI
 
 struct LoopAPNSRemoteView: View {
     @Environment(\.presentationMode) var presentationMode
-    @ObservedObject var loopAPNSSetup = Storage.shared.loopAPNSSetup
     @StateObject private var viewModel = RemoteSettingsViewModel()
 
     var body: some View {
@@ -18,7 +17,7 @@ struct LoopAPNSRemoteView: View {
                 ]
 
                 LazyVGrid(columns: columns, spacing: 16) {
-                    if loopAPNSSetup.value {
+                    if viewModel.loopAPNSSetup {
                         // Show Loop APNS command buttons if APNS setup configured
                         CommandButtonView(command: "Meal", iconName: "fork.knife", destination: LoopAPNSCarbsView())
                         CommandButtonView(command: "Bolus", iconName: "syringe", destination: LoopAPNSBolusView())
@@ -56,10 +55,6 @@ struct LoopAPNSRemoteView: View {
                 Spacer()
             }
             .navigationBarTitle("Loop Remote Control", displayMode: .inline)
-            .onAppear {
-                // Validate Loop APNS setup when view appears
-                viewModel.validateFullLoopAPNSSetup()
-            }
         }
     }
 }

--- a/LoopFollow/Remote/LoopAPNS/LoopAPNSSettingsView.swift
+++ b/LoopFollow/Remote/LoopAPNS/LoopAPNSSettingsView.swift
@@ -92,6 +92,7 @@ struct LoopAPNSSettingsView: View {
                     .buttonStyle(.borderedProminent)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 10)
+
                     VStack(alignment: .leading, spacing: 12) {
                         Text("Environment")
                             .font(.headline)
@@ -111,6 +112,7 @@ struct LoopAPNSSettingsView: View {
                         }
                         .padding(.top, 4)
                     }
+
                     VStack(alignment: .leading, spacing: 12) {
                         Text("Device Token")
                             .font(.headline)
@@ -193,21 +195,10 @@ struct LoopAPNSSettingsView: View {
                 }
             }
             .onAppear {
-                // Validate Loop APNS setup when view appears
-                viewModel.validateFullLoopAPNSSetup()
-
                 // Automatically fetch device token and bundle identifier when entering the setup screen
                 Task {
                     await viewModel.refreshDeviceToken()
                 }
-            }
-            .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("LoopAPNSSetupChanged"))) { _ in
-                // Update validation when Loop APNS setup changes
-                viewModel.validateFullLoopAPNSSetup()
-            }
-            .onDisappear {
-                // Force validation when leaving the settings view
-                viewModel.validateFullLoopAPNSSetup()
             }
         }
     }

--- a/LoopFollow/Remote/Settings/RemoteSettingsView.swift
+++ b/LoopFollow/Remote/Settings/RemoteSettingsView.swift
@@ -161,18 +161,6 @@ struct RemoteSettingsView: View {
 
         .preferredColorScheme(Storage.shared.forceDarkMode.value ? .dark : nil)
         .navigationBarTitle("Remote Settings", displayMode: .inline)
-        .onAppear {
-            // Refresh Loop APNS setup validation when returning to this screen
-            viewModel.validateFullLoopAPNSSetup()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("LoopAPNSSetupChanged"))) { _ in
-            // Update validation when Loop APNS setup changes
-            viewModel.validateFullLoopAPNSSetup()
-        }
-        .onDisappear {
-            // Force validation when leaving the settings view
-            viewModel.validateFullLoopAPNSSetup()
-        }
     }
 
     // MARK: - Custom Row for Remote Type Selection

--- a/LoopFollow/Storage/Storage.swift
+++ b/LoopFollow/Storage/Storage.swift
@@ -168,7 +168,6 @@ class Storage {
 
     // MARK: - Loop APNS Setup ---------------------------------------------------
 
-    var loopAPNSSetup = StorageValue<Bool>(key: "loopAPNSSetup", defaultValue: false)
     var loopAPNSQrCodeURL = StorageValue<String>(key: "loopAPNSQrCodeURL", defaultValue: "")
     var loopAPNSDeviceToken = StorageValue<String>(key: "loopAPNSDeviceToken", defaultValue: "")
     var loopAPNSBundleIdentifier = StorageValue<String>(key: "loopAPNSBundleIdentifier", defaultValue: "")


### PR DESCRIPTION
## Refactor Loop APNS Setup Validation to Use Computed Property

### Summary
Simplified the Loop APNS setup validation logic by replacing the complex state management system with a clean computed property approach.

### Changes
- Replaced `validateFullLoopAPNSSetup()` method with a computed property `loopAPNSSetup` that automatically derives its value from the required fields
- Removed `loopAPNSSetup` from Storage as it was redundant with the computed state
- Eliminated all manual validation calls from `onAppear`, `onDisappear`, and `onReceive` throughout the views
- Removed debouncing logic, state tracking variables, and circular dependency management code
- Cleaned up excessive logging statements related to validation

### Benefits
- **Simpler code**: No more manual validation triggers or state synchronization
- **More reliable**: Computed property always reflects the current state without timing issues
- **Better performance**: Eliminates redundant validation calls and notification observers
- **Easier maintenance**: Single source of truth for setup validation logic

### Technical Details
The `loopAPNSSetup` property now automatically returns `true` when all required fields (keyId, apnsKey, loopAPNSQrCodeURL, loopAPNSDeviceToken, loopAPNSBundleIdentifier) are non-empty. The UI reactively updates whenever any of these fields change.