### PR TITLE
Remove manual device token refresh and move debug info to main settings

### DIFF
--- a/LoopFollow/Remote/LoopAPNS/LoopAPNSSettingsView.swift
+++ b/LoopFollow/Remote/LoopAPNS/LoopAPNSSettingsView.swift
@@ -101,79 +101,6 @@ struct LoopAPNSSettingsView: View {
                         Text("Production is used for browser builders and should be switched off for Xcode builders")
                             .font(.caption)
                             .foregroundColor(.secondary)
-
-                        // Environment status indicator
-                        HStack {
-                            Image(systemName: viewModel.productionEnvironment ? "checkmark.circle.fill" : "gearshape.fill")
-                                .foregroundColor(viewModel.productionEnvironment ? .green : .blue)
-                            Text(viewModel.productionEnvironment ? "Production Environment" : "Development Environment")
-                                .font(.caption)
-                                .foregroundColor(viewModel.productionEnvironment ? .green : .blue)
-                        }
-                        .padding(.top, 4)
-                    }
-
-                    VStack(alignment: .leading, spacing: 12) {
-                        Text("Device Token")
-                            .font(.headline)
-                        HStack {
-                            Text(viewModel.loopAPNSDeviceToken.isEmpty ? "Not configured" : viewModel.loopAPNSDeviceToken)
-                                .foregroundColor(viewModel.loopAPNSDeviceToken.isEmpty ? .red : .primary)
-                                .font(.system(.body, design: .monospaced))
-                                .lineLimit(1)
-                                .truncationMode(.middle)
-
-                            Spacer()
-
-                            Button(action: {
-                                Task {
-                                    await viewModel.refreshDeviceToken()
-                                }
-                            }) {
-                                if viewModel.isRefreshingDeviceToken {
-                                    ProgressView()
-                                        .scaleEffect(0.8)
-                                } else {
-                                    Image(systemName: "arrow.clockwise")
-                                        .foregroundColor(.blue)
-                                }
-                            }
-                            .disabled(viewModel.isRefreshingDeviceToken)
-                        }
-
-                        // Device token status indicator
-                        if !viewModel.loopAPNSDeviceToken.isEmpty {
-                            HStack {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .foregroundColor(.green)
-                                Text("Device token configured")
-                                    .font(.caption)
-                                    .foregroundColor(.green)
-                            }
-                            .padding(.top, 4)
-                        }
-                    }
-
-                    VStack(alignment: .leading, spacing: 12) {
-                        Text("Bundle Identifier")
-                            .font(.headline)
-                        Text(viewModel.loopAPNSBundleIdentifier.isEmpty ? "Not configured" : viewModel.loopAPNSBundleIdentifier)
-                            .foregroundColor(viewModel.loopAPNSBundleIdentifier.isEmpty ? .red : .primary)
-                            .font(.system(.body, design: .monospaced))
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-
-                        // Bundle identifier status indicator
-                        if !viewModel.loopAPNSBundleIdentifier.isEmpty {
-                            HStack {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .foregroundColor(.green)
-                                Text("Bundle identifier configured")
-                                    .font(.caption)
-                                    .foregroundColor(.green)
-                            }
-                            .padding(.top, 4)
-                        }
                     }
 
                 } header: {
@@ -192,12 +119,6 @@ struct LoopAPNSSettingsView: View {
             .sheet(isPresented: $viewModel.isShowingLoopAPNSScanner) {
                 SimpleQRCodeScannerView { result in
                     viewModel.handleLoopAPNSQRCodeScanResult(result)
-                }
-            }
-            .onAppear {
-                // Automatically fetch device token and bundle identifier when entering the setup screen
-                Task {
-                    await viewModel.refreshDeviceToken()
                 }
             }
         }

--- a/LoopFollow/Remote/Settings/RemoteSettingsView.swift
+++ b/LoopFollow/Remote/Settings/RemoteSettingsView.swift
@@ -34,7 +34,7 @@ struct RemoteSettingsView: View {
                     remoteTypeRow(
                         type: .loopAPNS,
                         label: "Loop",
-                        isEnabled: true
+                        isEnabled: viewModel.isLoopDevice
                     )
                     remoteTypeRow(type: .nightscout, label: "Nightscout", isEnabled: true)
                     Text("Nightscout should be used for Trio 0.2.x or older.")
@@ -99,6 +99,8 @@ struct RemoteSettingsView: View {
                             .toggleStyle(SwitchToggleStyle())
                     }
 
+                    guardrailsSection
+
                     // MARK: - Debug / Info
 
                     Section(header: Text("Debug / Info")) {
@@ -137,12 +139,13 @@ struct RemoteSettingsView: View {
                             }
                         }
                     }
-                }
 
-                // MARK: - Shared Guardrails Section
-
-                if viewModel.remoteType != .none {
                     guardrailsSection
+
+                    Section(header: Text("Debug / Info")) {
+                        Text("Device Token: \(Storage.shared.loopAPNSDeviceToken.value)")
+                        Text("Bundle ID: \(Storage.shared.loopAPNSBundleIdentifier.value)")
+                    }
                 }
             }
             .alert(isPresented: $showAlert) {


### PR DESCRIPTION
## Summary
Removes manual device token refresh functionality and relocates debug information to the main remote settings page.

## Changes
- **Removed manual refresh functionality**: Eliminated `refreshDeviceToken()` method and related UI components since device tokens are automatically refreshed every 10 minutes in the background
- **Simplified APNS service**: Removed `getValidDeviceTokenAndBundle()` helper method and direct token validation logic
- **Moved debug information**: Relocated device token and bundle ID display from Loop APNS settings to the main remote settings page to align with Trio's settings layout
- **Updated Loop device detection**: Added `isLoopDevice` check to enable/disable Loop APNS option appropriately
- **Cleaned up UI**: Removed refresh button, progress indicators, and status displays from Loop APNS settings view

## Motivation
- Device tokens are already refreshed automatically every 10 minutes, making manual refresh redundant
- Aligns the settings page layout with Trio's design patterns
- Reduces UI complexity and potential user confusion
- Eliminates unnecessary network calls during configuration and remote command sending

## Testing
- [ ] Verify Loop APNS commands still work without manual token refresh
- [ ] Confirm debug information displays correctly on main remote settings page
- [ ] Test that automatic background refresh continues to work as expected